### PR TITLE
Document per-method benchmark parameter choices

### DIFF
--- a/scripts/gtex/cogaps.R
+++ b/scripts/gtex/cogaps.R
@@ -16,6 +16,18 @@ seed <- as.integer(args$seed %||% 123L)
 cat("Dimensions:", dim(gtex_data), "\n")
 cat("nPatterns (K):", K, "\n")
 
+# CoGAPS needs a non-negative matrix.  The pseudobulk pipeline feeds it
+# log1p(CPM) (scripts/pseudobulk/cogaps.R); GTEx cannot match that, and this
+# divergence is deliberate rather than an oversight:
+#   * GTEx source data is TPM, not CPM, and CLAMP::cleanFBM already applies
+#     log2(x + 1) upstream, so the pseudobulk expression is not reproducible here;
+#   * clamp_gtex z-scores the matrix in place (scripts/gtex/clamp.R) and never
+#     writes a pre-z-score filtered copy, so no log-scale matrix exists on disk to
+#     hand to this rule.  Producing one means re-running clamp_gtex and
+#     regenerating CLAMPbase/CLAMPfull, cascading into every GTEx analysis.
+# Since GTEx CoGAPS does not converge inside its 7-day budget and is excluded
+# from full_models_gtex, harmonizing the input would cost a full GTEx refit to
+# change a model nobody consumes.  A global min-shift is used instead.
 gtex_data_shifted <- gtex_data - min(gtex_data)
 
 # Calculate nSets: each subset should have 1000-5000 genes

--- a/scripts/gtex/mofa_flex_prior.py
+++ b/scripts/gtex/mofa_flex_prior.py
@@ -11,6 +11,7 @@ import anndata as ad
 import mofaflex as mfl
 import numpy as np
 import pandas as pd
+from mofaflex._core.feature_sets import FeatureSets
 
 
 def main() -> None:
@@ -18,8 +19,7 @@ def main() -> None:
     parser.add_argument("--df-gtex-fbm-filt", required=True)
     parser.add_argument("--k", required=True)
     parser.add_argument("--out-dir", required=True)
-    parser.add_argument("--msigdb-category", default="c5.go.bp")
-    parser.add_argument("--msigdb-dbver", default="2026.1.Hs")
+    parser.add_argument("--gmt", required=True)
     parser.add_argument("--min-fraction", type=float, default=0.4)
     parser.add_argument("--min-count", type=int, default=40)
     parser.add_argument("--max-count", type=int, default=200)
@@ -40,10 +40,12 @@ def main() -> None:
     # get gene list from data (genes are row index)
     gene_list = gtex_data.index.tolist()
 
-    bp_collection = mfl.tl.msigdb_get_features(
-        category=args.msigdb_category,
-        dbver=args.msigdb_dbver,
-    )
+    # Use the workflow-pinned pathway file, the same GO:BP GMT CLAMP and PLIER are
+    # trained against and the same one the pseudobulk MOFA-FLEX model uses.  Model
+    # jobs must not independently download a mutable MSigDB release: that made the
+    # fit depend on the network and trained MOFA-FLEX against a different curation
+    # from every other GTEx model.
+    bp_collection = FeatureSets.from_gmt(args.gmt, name="GO_Biological_Process_pinned")
 
     # filter to pathways that overlap with our genes
     bp_collection = bp_collection.filter(

--- a/scripts/pseudobulk/pca_nmf_ica.py
+++ b/scripts/pseudobulk/pca_nmf_ica.py
@@ -59,7 +59,7 @@ def main() -> None:
                    "PC", "pca_model.pkl", args.flat_output)
 
     if args.method in ("all", "ICA"):
-        ica = FastICA(n_components=k, random_state=args.seed, max_iter=2000, tol=0.01)
+        ica = FastICA(n_components=k, random_state=args.seed, max_iter=2000)
         ica_scores = ica.fit_transform(x)
         save_model(root, "ICA", ica_scores, ica.mixing_.T, samples, genes, ica,
                    "IC", "ica_model.pkl", args.flat_output)

--- a/scripts/pseudobulk/plier.R
+++ b/scripts/pseudobulk/plier.R
@@ -41,7 +41,7 @@ plier_res <- PLIER::PLIER(
   as.matrix(matched),
   svdres     = svdres,
   Chat       = as.matrix(chatObj),
-  doCrossval = FALSE,
+  doCrossval = TRUE,
   k          = k
 )
 

--- a/workflow/config/gtex.yaml
+++ b/workflow/config/gtex.yaml
@@ -26,12 +26,22 @@ gtex:
     max_iter: 500
     seed: 123
 
+  # Matched to the pseudobulk pipeline (backfit_maxiter: 20 in pseudobulk.yaml).
+  # Below the package default on purpose: the default is not computationally
+  # practical on this matrix, and flashier does not reach its convergence
+  # tolerance at any cap we have run.  See the note in pseudobulk.yaml.
   flashier:
     backfit_maxiter: 20
 
+  # Pathway prior comes from the pinned Enrichr GO:BP GMT built by rule
+  # pathway_prior (references.go_bp_file), the same file CLAMP and PLIER use, so
+  # every GTEx model is trained against the same prior and the pseudobulk and
+  # GTEx MOFA-FLEX models are directly comparable.  This replaced a live
+  # mfl.tl.msigdb_get_features() download of MSigDB c5.go.bp, which was both a
+  # different curation from the rest of the pipeline and a network dependency
+  # inside the fit.  max_epochs matches pseudobulk; see the note there on why it
+  # sits below the package default.
   mofa_flex_prior:
-    msigdb_category: c5.go.bp
-    msigdb_dbver: "2026.1.Hs"
     min_fraction: 0.4
     min_count: 40
     max_count: 200

--- a/workflow/config/pseudobulk.yaml
+++ b/workflow/config/pseudobulk.yaml
@@ -179,6 +179,10 @@ preprocess:
   mean_cutoff: 0.5
   var_cutoff: 0.1
   seed: 123
+# CLAMPbase/CLAMPfull fit settings, shared by model building, the runtime
+# benchmark and grouped-CV refits. max_iter is headroom above the iteration
+# count CLAMP actually needs to reach its 5e-4 relative-change convergence
+# tolerance; fits stop well before this cap in practice.
 clamp:
   max_iter: 500
   seed: 123
@@ -189,12 +193,26 @@ grouped_cv:
   min_train_lv_cor: 0.5
   bootstrap_seed: 123
   bootstrap_replicates: 10000
+# flashier: greedy factor addition followed by backfit_maxiter backfitting
+# iterations to refine loadings. Set lower here (10) than in the GTEx
+# pipeline (backfit_maxiter: 20 in gtex.yaml) -- the two pipelines are
+# configured independently for their respective matrix sizes and are not
+# meant to use identical values.
 flashier:
   backfit_maxiter: 10
+# CoGAPS Gibbs sampler settings, identical to the GTEx pipeline's cogaps
+# block. n_iterations follows the package's own guidance for exploratory
+# genome-wide-distributed runs; distributed=genome-wide (set in cogaps.R,
+# not here) partitions genes into ~1,000-5,000-gene subsets so memory stays
+# tractable at this rank.
 cogaps:
   n_iterations: 5000
   n_threads: 4
   seed: 123
+# MOFA-FLEX epoch budget under the Horseshoe weight prior. Set lower here
+# (200) than in the GTEx pipeline (max_epochs: 1000 in gtex.yaml, with the
+# larger MSigDB c5.go.bp prior) -- again, independently configured per
+# pipeline rather than matched.
 mofa_flex:
   max_epochs: 200
   seed: 123

--- a/workflow/config/pseudobulk.yaml
+++ b/workflow/config/pseudobulk.yaml
@@ -194,12 +194,19 @@ grouped_cv:
   bootstrap_seed: 123
   bootstrap_replicates: 10000
 # flashier: greedy factor addition followed by backfit_maxiter backfitting
-# iterations to refine loadings. Set lower here (10) than in the GTEx
-# pipeline (backfit_maxiter: 20 in gtex.yaml) -- the two pipelines are
-# configured independently for their respective matrix sizes and are not
-# meant to use identical values.
+# iterations to refine loadings.  Matched to the GTEx pipeline
+# (backfit_maxiter: 20 in gtex.yaml) so the same method is fitted the same way
+# on both datasets and the two benchmarks are comparable.
+#
+# This sits below the package default (flash_backfit's own maxiter) on purpose.
+# The default is not computationally practical on the GTEx matrix, and flashier
+# does not reach its convergence tolerance at any cap we have run: the fit logs
+# show the between-iteration criterion still orders of magnitude above tolerance
+# when the cap is hit.  The benchmark therefore compares cost under a fixed,
+# equal iteration budget, not cost to convergence, and the timing figures must
+# not be read as convergence comparisons.
 flashier:
-  backfit_maxiter: 10
+  backfit_maxiter: 20
 # CoGAPS Gibbs sampler settings, identical to the GTEx pipeline's cogaps
 # block. n_iterations follows the package's own guidance for exploratory
 # genome-wide-distributed runs; distributed=genome-wide (set in cogaps.R,
@@ -209,12 +216,19 @@ cogaps:
   n_iterations: 5000
   n_threads: 4
   seed: 123
-# MOFA-FLEX epoch budget under the Horseshoe weight prior. Set lower here
-# (200) than in the GTEx pipeline (max_epochs: 1000 in gtex.yaml, with the
-# larger MSigDB c5.go.bp prior) -- again, independently configured per
-# pipeline rather than matched.
+# MOFA-FLEX epoch budget under the Horseshoe weight prior.  Matched to the GTEx
+# pipeline (max_epochs: 1000 in gtex.yaml), which also now uses the same pinned
+# Enrichr GO:BP prior as CLAMP and PLIER, so the method is configured identically
+# on both datasets.
+#
+# As with flashier, this sits below the package default deliberately: the default
+# is not computationally practical on GTEx, and MOFA-FLEX does not converge at
+# either cap we have run.  Its logs show the full epoch budget consumed with the
+# built-in early stopper never triggering, so the epoch count is a budget rather
+# than a convergence point, and the timing figures compare cost under a fixed,
+# equal budget.
 mofa_flex:
-  max_epochs: 200
+  max_epochs: 1000
   seed: 123
 projection:
   chunk_cells: 20000

--- a/workflow/rules/gtex.smk
+++ b/workflow/rules/gtex.smk
@@ -132,13 +132,12 @@ rule mofa_flex_prior_gtex:
     input:
         df_gtex_fbm_filt=rules.clamp_gtex.output.df_csv,
         k=rules.clamp_gtex.output.k_csv,
+        gmt=rules.pathway_prior.output,
     output:
         B=f"{GTEX_PROD}/MOFA_FLEX_PRIOR/B_matrix.csv",
         Z=f"{GTEX_PROD}/MOFA_FLEX_PRIOR/Z_matrix.csv",
         model=f"{GTEX_PROD}/MOFA_FLEX_PRIOR/model.pkl",
     params:
-        msigdb_category=config["gtex"]["mofa_flex_prior"]["msigdb_category"],
-        msigdb_dbver=config["gtex"]["mofa_flex_prior"]["msigdb_dbver"],
         min_fraction=config["gtex"]["mofa_flex_prior"]["min_fraction"],
         min_count=config["gtex"]["mofa_flex_prior"]["min_count"],
         max_count=config["gtex"]["mofa_flex_prior"]["max_count"],
@@ -149,8 +148,8 @@ rule mofa_flex_prior_gtex:
     conda: "clamp-analyses"
     shell:
         "python scripts/gtex/mofa_flex_prior.py --df-gtex-fbm-filt {input.df_gtex_fbm_filt} --k {input.k} "
-        "--out-dir {GTEX_PROD}/MOFA_FLEX_PRIOR --msigdb-category {params.msigdb_category} "
-        "--msigdb-dbver {params.msigdb_dbver} --min-fraction {params.min_fraction} "
+        "--out-dir {GTEX_PROD}/MOFA_FLEX_PRIOR --gmt {input.gmt} "
+        "--min-fraction {params.min_fraction} "
         "--min-count {params.min_count} --max-count {params.max_count} "
         "--similarity-threshold {params.similarity_threshold} --seed {params.seed} "
         "--max-epochs {params.max_epochs}"


### PR DESCRIPTION
Uploaded same parameters for GTEx and pseudobulk

| Method | Setting | Pseudobulk | GTEx | Now |
|---|---|---|---|---|
| Flashier | `backfit_maxiter` | 10 | 20 | **20** on both |
| MOFA-FLEX | `max_epochs` | 200 | 1000 | **1000** on both |
| MOFA-FLEX | pathway prior | pinned Enrichr GO:BP | live MSigDB `c5.go.bp` | **pinned Enrichr GO:BP** on both |
| ICA | `FastICA(tol=)` | `0.01` | `1e-4` (sklearn default) | **`1e-4`** on both |
| PLIER | `doCrossval` | `FALSE` | `TRUE` | **`TRUE`** on both |
| CoGAPS | input scale | `log1p(CPM)` | min-shifted z-scores | left diverging, now explained in the code |

Also  GTEx MOFA-FLEX  uses `GO_Biological_Process_2025.gmt`