### PR TITLE
Log-transform pseudobulk CPM before filtering, matching GTEx

### DIFF
--- a/scripts/pseudobulk/cogaps.R
+++ b/scripts/pseudobulk/cogaps.R
@@ -16,11 +16,12 @@ parallel_workers <- if (!is.null(args$parallel_workers)) {
 }
 seed <- as.integer(args$seed %||% 123L)
 
-# cpm_filt is already non-negative (CLAMP::cpmCLAMP + preprocessCLAMP, pre-z-score).
-# log1p it as CoGAPS's own vignette does for count-scale data -- raw CPM values run into
-# the tens/hundreds of thousands, which is well outside the range CoGAPS's Gibbs sampler
-# expects (it warns "Large values detected, is data log transformed?" without this).
-mat <- log1p(loaded$norm)
+# cpm_filt is the filtered log2(CPM + 1) matrix from preprocess.R: non-negative and
+# already on the log scale CoGAPS's Gibbs sampler expects (without a log transform it
+# warns "Large values detected, is data log transformed?").  The log1p that used to be
+# applied here was removed when preprocess.R started log-transforming before filtering,
+# to match the GTEx pipeline -- keeping it would have transformed the data twice.
+mat <- loaded$norm
 
 # Distributed genome-wide CoGAPS: each subset should have 1000-5000 genes
 nSets <- max(ceiling(nrow(mat) / 2500), 2L)

--- a/scripts/pseudobulk/preprocess.R
+++ b/scripts/pseudobulk/preprocess.R
@@ -23,7 +23,24 @@ set.seed(seed)
 counts <- read_csv_matrix(input)
 if (!all(is.finite(counts)) || any(counts < 0)) stop("Input contains non-finite or negative values")
 cpm <- CLAMP::cpmCLAMP(counts)
-prep <- CLAMP::preprocessCLAMP(cpm, mean_cutoff = mean_cutoff, var_cutoff = var_cutoff)
+
+# Log-transform before filtering, matching the GTEx pipeline.
+#
+# The two pipelines enter CLAMP through different doors: GTEx builds an FBM and
+# calls preprocessCLAMPFBM, which runs cleanFBM and applies log2(x + 1) whenever
+# the matrix maximum is >= 100.  Pseudobulk calls the in-memory preprocessCLAMP,
+# which does no transform at all and assumes the caller passes data on a suitable
+# scale.  Without this line the pipelines differed in two ways: GTEx modelled
+# log2 data while pseudobulk modelled raw CPM, and -- more subtly -- the shared
+# mean_cutoff/var_cutoff were applied to incomparable scales, so identical config
+# values selected genes by different criteria (linear CPM row variances here run
+# to 1e7, against a var_cutoff of 0.1).
+#
+# cleanFBM's >= 100 condition is always true for CPM, so it is applied
+# unconditionally rather than reproducing a branch that never takes the else.
+log_cpm <- log2(cpm + 1)
+
+prep <- CLAMP::preprocessCLAMP(log_cpm, mean_cutoff = mean_cutoff, var_cutoff = var_cutoff)
 norm <- CLAMP::zscoreCLAMP(prep$Y_filtered, prep$rowStats)
 
 # SVD
@@ -43,6 +60,10 @@ diagnostics <- data.frame(
 )
 
 write_csv_matrix(norm, norm_out)
+# NOTE: despite the file name, this is now the filtered log2(CPM + 1) matrix, not
+# raw CPM.  It is the pre-z-score matrix CoGAPS consumes, and CoGAPS no longer
+# log-transforms it itself.  The name is kept because renaming it ripples through
+# pseudobulk.smk, donor_bulk.smk, computational_timing.smk and the timing driver.
 write_csv_matrix(prep$Y_filtered, cpm_filt_out)
 write_csv_matrix(prep$rowStats, stats_out)
 ensure_parent(k_out); fwrite(data.frame(k = k), k_out)


### PR DESCRIPTION
## The problem

The two pipelines enter CLAMP through different doors, and only one of them log-transforms.

**GTEx** (`scripts/gtex/clamp.R`) builds an FBM and calls `preprocessCLAMPFBM`, which runs `cleanFBM`:

```r
if (!is.na(max_value) && max_value >= 100) {
    message("Applying log2 transformation")
    X[, ind] <- log2(X[, ind] + 1)
}
```

TPM always exceeds 100, so GTEx models `log2(x + 1)` data.

**Pseudobulk** (`scripts/pseudobulk/preprocess.R`) calls the in-memory `preprocessCLAMP`, which only computes row mean/variance and filters. It applies no transform and assumes the caller passes data on a suitable scale. The script never added one, so pseudobulk modelled **raw linear CPM**.

## Why the second-order effect is worse

Both configs set `mean_cutoff: 0.5` and `var_cutoff: 0.1`. Those were being applied to incomparable scales. Measured row statistics for retained pseudobulk genes, on the linear CPM scale:

| Dataset | median mean | median variance | max variance |
|---|---|---|---|
| PBMC_1k1k | 8.44 | 9.31 | 7.97e7 |
| Brain_Mathys2023 | 23.0 | 52.8 | 5.46e6 |

A `var_cutoff` of 0.1 against a median variance of 9 to 53 removes essentially nothing. On a log2 scale the same number is a real filter. So identical-looking configuration was **selecting genes by different criteria in the two pipelines**, which is easy to miss when reading either config alone.

## The fix

`preprocess.R` applies `log2(cpm + 1)` before `preprocessCLAMP`, so filtering, z-scoring and every downstream model see the same scale as GTEx. `cleanFBM`'s `>= 100` condition is always true for CPM, so the transform is unconditional rather than reproducing a branch that never takes its else.

`cogaps.R` previously applied `log1p` to `cpm_filt` itself. Left alone that would now transform twice, so it is removed; its input is already log-scale and non-negative, which is what its comment wanted in the first place.

The `cpm_filt` file name is kept even though it now holds `log2(CPM + 1)`, because renaming ripples through `pseudobulk.smk`, `donor_bulk.smk`, `computational_timing.smk` and the timing driver. Both producer and consumer say so explicitly instead. Renaming is a reasonable follow-up.

## Scope of the recompute

This is the widest of the current changes. It invalidates:

- both pseudobulk preprocessing stages (`norm`, `cpm_filt`, `row_stats`, and `k`, which is estimated from the transformed matrix)
- **every pseudobulk model including CLAMP**, on all six datasets
- all 180 pseudobulk timing fits
- grouped CV and the single-cell projections
- **the entire donor-bulk pipeline**, since `donor_bulk.smk` calls the same `preprocess.R`
- all pseudobulk biology reports and every figure panel

GTEx is unaffected: it was already the log2 side.

## Worth checking before the rebuild

Because `var_cutoff: 0.1` was near-inert on the linear scale and becomes meaningful on log2, the number of retained genes will drop, and `k` moves with it. That is the correct behaviour, but the cutoffs may deserve revisiting now that they mean what they appear to mean. Worth measuring retained-gene counts on one dataset before committing to the full rebuild.

Kept separate from #21, which covers the method-parameter harmonization and the GTEx timing benchmark.