### PR TITLE
Recalibrate the pseudobulk gene filter for the log2 scale

### DIFF
--- a/workflow/config/pseudobulk.yaml
+++ b/workflow/config/pseudobulk.yaml
@@ -175,9 +175,34 @@ references:
   gtex_tissues_pathmat: data/archs4/GTEx_Tissues_pathMat.rds
   brain_datasets: [Brain_Mathys2023, Brain_Xiong2023]
 
+# Gene filter applied after CPM normalization and the log2(x + 1) transform in
+# scripts/pseudobulk/preprocess.R.  Deliberately NOT the same as the GTEx values
+# (gtex.yaml keeps mean_cutoff: 0.5, var_cutoff: 0.1), and that is not an oversight.
+#
+# These cutoffs were originally tuned against linear CPM, where var_cutoff: 0.1 was
+# effectively inert: measured row variances had medians of 9-53 and maxima near 1e7,
+# so almost nothing was removed and the filter was in practice mean-only.  Once
+# preprocessing was corrected to log2 the same 0.1 became a real filter, removing
+# 16-23% of genes, and the elbow-based rank estimate on the largest dataset
+# collapsed from k=130 to k=62.  Values calibrated on one scale do not transfer to
+# another, so they were recalibrated to preserve the filter's previous effective
+# selectivity rather than its literal numbers.
+#
+# At 0.25/0.01 the inferred k is unchanged from the pre-log2 pipeline on five of the
+# six datasets (Brain_Mathys2023 19, Brain_Xiong2023 18, PBMC_1k1k 130,
+# PBMC_Perez2022 52, Heart_Datar2026 52); only Lung_Sikkema2023 moves, 18 -> 24, and
+# it does so under every cutoff tested.  Retained gene sets run 6-11% larger than the
+# pre-log2 ones.  It is mean_cutoff that governs the rank: lowering it readmits the
+# low-expression genes carrying those components, whereas varying var_cutoff alone
+# only moved PBMC_1k1k from 62 to 74.
+#
+# GTEx keeps its own values because it is bulk tissue rather than aggregated
+# single-cell profiles, with a different per-gene variance distribution.  Note this
+# is a deliberate exception to the method-parameter harmonization: the iteration caps
+# below are matched to GTEx, these preprocessing cutoffs are not.
 preprocess:
-  mean_cutoff: 0.5
-  var_cutoff: 0.1
+  mean_cutoff: 0.25
+  var_cutoff: 0.01
   seed: 123
 # CLAMPbase/CLAMPfull fit settings, shared by model building, the runtime
 # benchmark and grouped-CV refits. max_iter is headroom above the iteration


### PR DESCRIPTION
One-line config change, plus the reasoning as a comment.

```yaml
preprocess:
  mean_cutoff: 0.25   # was 0.5
  var_cutoff: 0.01    # was 0.1
```

## Why

#22 corrected pseudobulk preprocessing to `log2(CPM + 1)` before filtering. That exposed a latent problem in the cutoffs, which had been tuned against linear CPM.

On the old linear scale, `var_cutoff: 0.1` was **effectively inert**. Measured row variances for retained genes:

| Dataset | median mean | median variance | max variance |
|---|---|---|---|
| PBMC_1k1k | 8.44 | 9.31 | 7.97e7 |
| Brain_Mathys2023 | 23.0 | 52.8 | 5.46e6 |

A cutoff of 0.1 against a median of 9-53 removes almost nothing, so the filter was in practice mean-only. On the log2 scale (median variance 0.27) the same 0.1 became a real filter: 16-23% of genes removed, and the elbow-based rank estimate on the largest dataset collapsed from `k=130` to `k=62`.

Values calibrated on one scale do not carry over to another. These were recalibrated to preserve the filter's previous *effective* selectivity rather than its literal numbers.

## What was measured

`k` is the right thing to watch, because it sets how many components every method fits and therefore drives LV↔cell-type assignments, the method comparison and the figure panels.

| Setting | Gene sets vs pre-log2 | k unchanged | PBMC_1k1k k (was 130) |
|---|---|---|---|
| 0.5 / 0.1 (as GTEx) | 16-23% fewer | 3 of 6 | 62 |
| 0.5 / 0.02 | within ~1% | 4 of 6 | 74 |
| **0.25 / 0.01 (this PR)** | 6-11% larger | **5 of 6** | **130** |

Under 0.25/0.01: Brain_Mathys2023 19, Brain_Xiong2023 18, PBMC_1k1k 130, PBMC_Perez2022 52, Heart_Datar2026 52 — all identical to the pre-log2 pipeline. Only Lung_Sikkema2023 moves, 18 → 24, and it does so under **every** cutoff tested, so that change is unavoidable.

It is `mean_cutoff` that governs the rank, not `var_cutoff`: lowering it readmits the low-expression genes carrying those components. Varying `var_cutoff` alone only moved PBMC_1k1k from 62 to 74, so a variance-only change could not have fixed it.

## Deliberate divergence from GTEx

GTEx keeps `0.5 / 0.1`. It is bulk tissue rather than aggregated single-cell profiles, with a different per-gene variance distribution, and applying pseudobulk's values there would change models that are currently correct.

This is an explicit exception to the harmonization in #21: the **iteration caps stay matched** to GTEx, the **preprocessing cutoffs deliberately do not**. The config comment states this so the next reader does not "fix" it back.

## Caveat

`k` is a proxy. Matching `k` and near-matching gene sets make similar results likely, but the z-scored values differ under log2 on every dataset, so results can still move. Worth checking PBMC_1k1k and Lung_Sikkema2023 against the baseline in the committed executed notebooks once the models are refit.

No behaviour is exercised until the pseudobulk models are regenerated, which is the next piece of work.